### PR TITLE
feat: Add initial storage implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@playwright/experimental-ct-react": "^1.42.1",
         "@playwright/test": "^1.42.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-        "@types/chrome": "^0.0.202",
+        "@types/chrome": "^0.0.263",
         "@types/node": "^20.11.21",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
@@ -123,15 +123,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
@@ -187,15 +178,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -1611,9 +1593,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.202.tgz",
-      "integrity": "sha512-Oc4daL9sFS+9MToVZPLMBxR7PxsEdod0b8wOY11lRr06GJp43MORvHeDyMD8QzeRGT6HI13oaYAe2PBgvALc4w==",
+      "version": "0.0.263",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.263.tgz",
+      "integrity": "sha512-As0vzv99ov3M6ZR7R6VzhMWFZXkPMrFrCEXXVrMN576Cm70fTkj7Df2CF+qEo170JepX50pd11cX6O4DSAtl2Q==",
       "dev": true,
       "dependencies": {
         "@types/filesystem": "*",
@@ -11045,14 +11027,6 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
         "semver": "^6.3.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        }
       }
     },
     "@babel/generator": {
@@ -11100,14 +11074,6 @@
         "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -11992,9 +11958,9 @@
       }
     },
     "@types/chrome": {
-      "version": "0.0.202",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.202.tgz",
-      "integrity": "sha512-Oc4daL9sFS+9MToVZPLMBxR7PxsEdod0b8wOY11lRr06GJp43MORvHeDyMD8QzeRGT6HI13oaYAe2PBgvALc4w==",
+      "version": "0.0.263",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.263.tgz",
+      "integrity": "sha512-As0vzv99ov3M6ZR7R6VzhMWFZXkPMrFrCEXXVrMN576Cm70fTkj7Df2CF+qEo170JepX50pd11cX6O4DSAtl2Q==",
       "dev": true,
       "requires": {
         "@types/filesystem": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@playwright/experimental-ct-react": "^1.42.1",
     "@playwright/test": "^1.42.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-    "@types/chrome": "^0.0.202",
+    "@types/chrome": "^0.0.263",
     "@types/node": "^20.11.21",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,7 @@
   "side_panel": {
     "default_path": "panel.html"
   },
-  "permissions": ["sidePanel"],
+  "permissions": ["sidePanel", "storage"],
   "icons": {
     "128": "icon-128.png"
   },

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1,5 +1,7 @@
 console.log('This is the background page.');
 console.log('Put the background scripts here.');
+import { defaultSettings } from '../../../utils/settings';
+
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => console.error(error));
@@ -11,4 +13,8 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
       `Old value was "${oldValue}", new value is "${newValue}".`
     );
   }
+});
+
+chrome.storage.sync.set({
+  ...defaultSettings,
 });

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -3,3 +3,12 @@ console.log('Put the background scripts here.');
 chrome.sidePanel
   .setPanelBehavior({ openPanelOnActionClick: true })
   .catch((error) => console.error(error));
+
+chrome.storage.onChanged.addListener((changes, namespace) => {
+  for (let [key, { oldValue, newValue }] of Object.entries(changes)) {
+    console.log(
+      `Storage key "${key}" in namespace "${namespace}" changed.`,
+      `Old value was "${oldValue}", new value is "${newValue}".`
+    );
+  }
+});

--- a/src/pages/Options/Options.css
+++ b/src/pages/Options/Options.css
@@ -1,8 +1,31 @@
-.OptionsContainer {
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+:root {
+  font-family: 'Noto sans', sans-serif;
+}
+
+.options-container {
   width: 100%;
   height: 50vh;
-  font-size: 2rem;
+  font-size: 1rem;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  margin: 0 auto;
+  gap: 0.5rem;
+}
+
+h1 {
+  font-size: 2rem;
+}
+
+.options-container * {
+  margin: 0 auto;
+}
+
+.error-message {
+  color: red;
+}
+
+.status-message {
+  color: green;
 }

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -11,6 +11,21 @@ const Options: React.FC<Props> = ({ title }: Props) => {
   const [status, setStatus] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');
 
+  useEffect(() => {
+    try {
+      chrome.storage.sync.get(defaultSettings, (storedSettings) => {
+        setSettings({ ...storedSettings } as Settings);
+      });
+    } catch (error) {
+      console.error(error);
+      if (error instanceof Error) {
+        displayError(`Error: ${error.message}`, 5000);
+      } else {
+        displayError('Something went wrong.', 5000);
+      }
+    }
+  }, []);
+
   const displayStatus = (message: string, ms: number) => {
     setStatus(message);
     const id = setTimeout(() => {
@@ -26,21 +41,6 @@ const Options: React.FC<Props> = ({ title }: Props) => {
     }, ms);
     return () => clearTimeout(id);
   };
-
-  useEffect(() => {
-    try {
-      chrome.storage.sync.get(defaultSettings, (storedSettings) => {
-        setSettings({ ...storedSettings } as Settings);
-      });
-    } catch (error) {
-      console.error(error);
-      if (error instanceof Error) {
-        displayError(`Error: ${error.message}`, 5000);
-      } else {
-        displayError('Something went wrong.', 5000);
-      }
-    }
-  }, []);
 
   const saveSettings = () => {
     try {
@@ -103,15 +103,24 @@ const Options: React.FC<Props> = ({ title }: Props) => {
   };
 
   const exportSettings = () => {
-    chrome.storage.sync.get(null, function (items) {
-      const settingsJSON = JSON.stringify(items);
-      const blob = new Blob([settingsJSON], { type: 'application/json' });
+    try {
+      chrome.storage.sync.get(null, function (items) {
+        const settingsJSON = JSON.stringify(items);
+        const blob = new Blob([settingsJSON], { type: 'application/json' });
 
-      const downloadLink = document.createElement('a');
-      downloadLink.download = 'studysync_settings.json';
-      downloadLink.href = URL.createObjectURL(blob);
-      downloadLink.click();
-    });
+        const downloadLink = document.createElement('a');
+        downloadLink.download = 'studysync_settings.json';
+        downloadLink.href = URL.createObjectURL(blob);
+        downloadLink.click();
+      });
+    } catch (error) {
+      console.error(error);
+      if (error instanceof Error) {
+        displayError(`Error: ${error.message}`, 5000);
+      } else {
+        displayError('Something went wrong.', 5000);
+      }
+    }
   };
 
   return (

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Settings } from '../../types';
 import './Options.css';
 
 interface Props {
@@ -6,7 +7,98 @@ interface Props {
 }
 
 const Options: React.FC<Props> = ({ title }: Props) => {
-  return <div className="OptionsContainer">{title} Page</div>;
+  const defaultSettings = {
+    workTime: 25,
+    breakTime: 5,
+  };
+
+  const [settings, setSettings] = useState<Settings>(defaultSettings);
+  const [status, setStatus] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
+
+  const displayStatus = (message: string, ms: number) => {
+    setStatus(message);
+    const id = setTimeout(() => {
+      setStatus('');
+    }, ms);
+    return () => clearTimeout(id);
+  };
+
+  const displayError = (message: string, ms: number) => {
+    setErrorMessage(message);
+    const id = setTimeout(() => {
+      setErrorMessage('');
+    }, ms);
+    return () => clearTimeout(id);
+  };
+
+  useEffect(() => {
+    try {
+      chrome.storage.sync.get(defaultSettings, (storedSettings) => {
+        setSettings({ ...storedSettings } as Settings);
+      });
+    } catch (error) {
+      console.error(error);
+      if (error instanceof Error) {
+        displayError(`Error: ${error.message}`, 5000);
+      } else {
+        displayError('Something went wrong.', 5000);
+      }
+    }
+  }, []);
+
+  const saveSettings = () => {
+    try {
+      chrome.storage.sync.set(
+        {
+          ...settings,
+        },
+        () => {
+          displayStatus('Options saved.', 1000);
+        }
+      );
+    } catch (error) {
+      console.error(error);
+      if (error instanceof Error) {
+        displayError(`Error: ${error.message}`, 5000);
+      } else {
+        displayError('Something went wrong.', 5000);
+      }
+    }
+  };
+
+  return (
+    <div className="options-container">
+      <h1>{title} Page</h1>
+      <div>
+        <label htmlFor="work-time">Work time (in minutes)</label>
+        <input
+          type="number"
+          name="work-time"
+          min={1}
+          value={settings.workTime}
+          onChange={(event) =>
+            setSettings({ ...settings, workTime: Number(event.target.value) })
+          }
+        ></input>
+      </div>
+      <div>
+        <label htmlFor="break-time">Break time (in minutes)</label>
+        <input
+          type="number"
+          name="break-time"
+          min={1}
+          value={settings.breakTime}
+          onChange={(event) =>
+            setSettings({ ...settings, breakTime: Number(event.target.value) })
+          }
+        ></input>
+      </div>
+      <div className="error-message">{errorMessage}</div>
+      <div className="status-message">{status}</div>
+      <button onClick={saveSettings}>Save</button>
+    </div>
+  );
 };
 
 export default Options;

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -132,9 +132,15 @@ const Options: React.FC<Props> = ({ title }: Props) => {
           type="number"
           name="work-time"
           min={1}
-          value={settings.workTime}
+          value={settings.pomodoro.workTime}
           onChange={(event) =>
-            setSettings({ ...settings, workTime: Number(event.target.value) })
+            setSettings({
+              ...settings,
+              pomodoro: {
+                ...settings.pomodoro,
+                workTime: Number(event.target.value),
+              },
+            })
           }
         ></input>
       </div>
@@ -144,9 +150,15 @@ const Options: React.FC<Props> = ({ title }: Props) => {
           type="number"
           name="break-time"
           min={1}
-          value={settings.breakTime}
+          value={settings.pomodoro.breakTime}
           onChange={(event) =>
-            setSettings({ ...settings, breakTime: Number(event.target.value) })
+            setSettings({
+              ...settings,
+              pomodoro: {
+                ...settings.pomodoro,
+                breakTime: Number(event.target.value),
+              },
+            })
           }
         ></input>
       </div>

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -62,6 +62,58 @@ const Options: React.FC<Props> = ({ title }: Props) => {
     }
   };
 
+  const importSettings = () => {
+    const fileInput = document.createElement('input');
+    fileInput.type = 'file';
+    fileInput.accept = '.json';
+    fileInput.style.display = 'none';
+
+    fileInput.onchange = function (event) {
+      const target = event.target as HTMLInputElement;
+      const files = target.files;
+      if (!files || files.length === 0) return;
+
+      const file = files[0];
+      const reader = new FileReader();
+
+      reader.onload = function (e: ProgressEvent<FileReader>) {
+        const settingsJSON = e.target?.result as string;
+        const settings = JSON.parse(settingsJSON) as Settings;
+
+        try {
+          chrome.storage.sync.set(settings, () => {
+            displayStatus('Settings imported successfully.', 3000);
+            setSettings({ ...settings } as Settings);
+          });
+        } catch (error) {
+          console.error(error);
+          if (error instanceof Error) {
+            displayError(`Error: ${error.message}`, 5000);
+          } else {
+            displayError('Something went wrong.', 5000);
+          }
+        }
+      };
+
+      reader.readAsText(file);
+    };
+
+    document.body.appendChild(fileInput);
+    fileInput.click();
+  };
+
+  const exportSettings = () => {
+    chrome.storage.sync.get(null, function (items) {
+      const settingsJSON = JSON.stringify(items);
+      const blob = new Blob([settingsJSON], { type: 'application/json' });
+
+      const downloadLink = document.createElement('a');
+      downloadLink.download = 'studysync_settings.json';
+      downloadLink.href = URL.createObjectURL(blob);
+      downloadLink.click();
+    });
+  };
+
   return (
     <div className="options-container">
       <h1>{title} Page</h1>
@@ -92,6 +144,10 @@ const Options: React.FC<Props> = ({ title }: Props) => {
       <div className="error-message">{errorMessage}</div>
       <div className="status-message">{status}</div>
       <button onClick={saveSettings}>Save</button>
+      <div>
+        <button onClick={importSettings}>Import Settings</button>{' '}
+        <button onClick={exportSettings}>Export Settings</button>
+      </div>
     </div>
   );
 };

--- a/src/pages/Options/Options.tsx
+++ b/src/pages/Options/Options.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Settings } from '../../types';
+import { Settings, defaultSettings } from '../../../utils/settings';
 import './Options.css';
 
 interface Props {
@@ -7,11 +7,6 @@ interface Props {
 }
 
 const Options: React.FC<Props> = ({ title }: Props) => {
-  const defaultSettings = {
-    workTime: 25,
-    breakTime: 5,
-  };
-
   const [settings, setSettings] = useState<Settings>(defaultSettings);
   const [status, setStatus] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>('');

--- a/src/pages/Panel/subpanel/Pomodoro.tsx
+++ b/src/pages/Panel/subpanel/Pomodoro.tsx
@@ -34,7 +34,7 @@ const Pomodoro: React.FC = () => {
 
     initTimer();
 
-    secondsLeftRef.current = settings.workTime * 60;
+    secondsLeftRef.current = settings.pomodoro.workTime * 60;
     setSecondsLeft(secondsLeftRef.current);
 
     const interval = setInterval(() => {
@@ -58,12 +58,12 @@ const Pomodoro: React.FC = () => {
     setIsPaused(true);
     isPausedRef.current = true;
     initTimer();
-    secondsLeftRef.current = settings.workTime * 60;
+    secondsLeftRef.current = settings.pomodoro.workTime * 60;
     setSecondsLeft(secondsLeftRef.current);
   }, [settings]);
 
   function initTimer() {
-    setSecondsLeft(settings.workTime * 60);
+    setSecondsLeft(settings.pomodoro.workTime * 60);
   }
 
   function tick() {
@@ -74,7 +74,9 @@ const Pomodoro: React.FC = () => {
   function switchMode() {
     const nextMode: string = modeRef.current === 'work' ? 'break' : 'work';
     const nextSeconds: number =
-      (nextMode === 'work' ? settings.workTime : settings.breakTime) * 60;
+      (nextMode === 'work'
+        ? settings.pomodoro.workTime
+        : settings.pomodoro.breakTime) * 60;
 
     setMode(nextMode);
     modeRef.current = nextMode;

--- a/src/pages/Panel/subpanel/Pomodoro.tsx
+++ b/src/pages/Panel/subpanel/Pomodoro.tsx
@@ -14,27 +14,6 @@ const Pomodoro: React.FC = () => {
   const modeRef = useRef(mode);
   const secondsLeftRef = useRef(secondsLeft);
 
-  function initTimer() {
-    setSecondsLeft(settings.workTime * 60);
-  }
-
-  function tick() {
-    secondsLeftRef.current--;
-    setSecondsLeft(secondsLeftRef.current);
-  }
-
-  function switchMode() {
-    const nextMode: string = modeRef.current === 'work' ? 'break' : 'work';
-    const nextSeconds: number =
-      (nextMode === 'work' ? settings.workTime : settings.breakTime) * 60;
-
-    setMode(nextMode);
-    modeRef.current = nextMode;
-
-    setSecondsLeft(nextSeconds);
-    secondsLeftRef.current = nextSeconds;
-  }
-
   useEffect(() => {
     try {
       // Get existing settings from storage
@@ -82,6 +61,27 @@ const Pomodoro: React.FC = () => {
     secondsLeftRef.current = settings.workTime * 60;
     setSecondsLeft(secondsLeftRef.current);
   }, [settings]);
+
+  function initTimer() {
+    setSecondsLeft(settings.workTime * 60);
+  }
+
+  function tick() {
+    secondsLeftRef.current--;
+    setSecondsLeft(secondsLeftRef.current);
+  }
+
+  function switchMode() {
+    const nextMode: string = modeRef.current === 'work' ? 'break' : 'work';
+    const nextSeconds: number =
+      (nextMode === 'work' ? settings.workTime : settings.breakTime) * 60;
+
+    setMode(nextMode);
+    modeRef.current = nextMode;
+
+    setSecondsLeft(nextSeconds);
+    secondsLeftRef.current = nextSeconds;
+  }
 
   let minutes: string = String(Math.floor(secondsLeft / 60));
   let seconds: string = String(secondsLeft % 60);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export interface Settings {
+  workTime: number;
+  breakTime: number;
+}

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -1,9 +1,13 @@
 export interface Settings {
-  workTime: number;
-  breakTime: number;
+  pomodoro: {
+    workTime: number;
+    breakTime: number;
+  };
 }
 
 export const defaultSettings = {
-  workTime: 25,
-  breakTime: 5,
+  pomodoro: {
+    workTime: 25,
+    breakTime: 5,
+  },
 };

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -2,3 +2,8 @@ export interface Settings {
   workTime: number;
   breakTime: number;
 }
+
+export const defaultSettings = {
+  workTime: 25,
+  breakTime: 5,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,7 +129,7 @@ var options = {
       .concat(['.js', '.jsx', '.ts', '.tsx', '.css']),
   },
   plugins: [
-    isDevelopment && new ReactRefreshWebpackPlugin(),
+    isDevelopment && new ReactRefreshWebpackPlugin({ overlay: false }),
     new CleanWebpackPlugin({ verbose: false }),
     new webpack.ProgressPlugin(),
     // expose and write the allowed env vars on the compiled bundle


### PR DESCRIPTION
This PR does the ff:
- Allow for custom pomodoro intervals
- Use `chrome.storage.sync` to store settings

Note: `chrome.<property>` is undefined when loading the extension through `npm run start`. For now wrap usage in try-catch blocks and use built extension when developing chrome api-related features